### PR TITLE
Fix Mace Head recipe with schematic and fix vanilla tool recipe removal config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ out
 # gradle
 build
 .gradle
+gradle.properties
 
 # other
 .nb-gradle
@@ -23,4 +24,3 @@ eclipse
 run
 libs
 .nb-gradle-properties
-.properties

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ eclipse
 run
 libs
 .nb-gradle-properties
+.properties

--- a/src/main/java/toolbox/common/Config.java
+++ b/src/main/java/toolbox/common/Config.java
@@ -19,6 +19,7 @@ public class Config {
 	private final static List<String> PROPERTY_ORDER_COMPAT = new ArrayList<>();
 	
 	public static boolean DISABLE_VANILLA_TOOLS;
+	public static boolean DISABLE_ALL_VANILLA_TOOLS;
 	public static boolean HIDE_UNCRAFTABLE_HEADS;
 	public static boolean SPAWN_WITH_BOOK;
 	
@@ -56,7 +57,8 @@ public class Config {
 		cfg.addCustomCategoryComment(CATEGORY_SCHEMATICS, "Schematics Options");
 		cfg.addCustomCategoryComment(CATEGORY_COMPAT, "Compatability Options");
 
-		DISABLE_VANILLA_TOOLS = cfg.getBoolean("Disable Vanilla Tools", CATEGORY_GENERAL, true, "This option disables recipes for vanilla tools.\nIt also attempts to replace all instances of vanilla tools in crafting recipes (including mod recipes) with suitable replacements from Adventurer's Toolbox.\n");
+		DISABLE_VANILLA_TOOLS = cfg.getBoolean("Disable Vanilla Tools", CATEGORY_GENERAL, true, "This option disables recipes for vanilla tools that contain materials this mod supports.\nIt also attempts to replace all instances of vanilla tools in crafting recipes (including mod recipes) with suitable replacements from Adventurer's Toolbox.\n");
+		DISABLE_ALL_VANILLA_TOOLS = cfg.getBoolean("Disable All Vanilla Tools", CATEGORY_GENERAL, false, "This option disables and attempts to replace recipes for vanilla tools using any materials.\nThis only works if Disable Vanilla Tools is true.");
 		HIDE_UNCRAFTABLE_HEADS = cfg.getBoolean("Hide Uncraftables", CATEGORY_GENERAL, true, "This option prevents tool heads from showing up in the creative tab if they are made from materials that aren't present in your game.\n");
 		SPAWN_WITH_BOOK= cfg.getBoolean("Spawn With Book", CATEGORY_GENERAL, true, "Disable this if you don't want to be given the guide book when first joining a world.\n");
 		
@@ -74,6 +76,7 @@ public class Config {
 		DISABLE_TOOL_HEAD_RECIPES = cfg.getBoolean("Disable Metal Tool Head Recipes", CATEGORY_COMPAT, false, "This option disables the crafting recipes for any materials that get added as a casting recipe\n");
 		
 		PROPERTY_ORDER_GENERAL.add("Disable Vanilla Tools");
+		PROPERTY_ORDER_GENERAL.add("Disable All Vanilla Tools");
 		PROPERTY_ORDER_GENERAL.add("Hide Uncraftables");
 		PROPERTY_ORDER_GENERAL.add("Spawn With Book");
 		

--- a/src/main/java/toolbox/common/materials/ModMaterials.java
+++ b/src/main/java/toolbox/common/materials/ModMaterials.java
@@ -73,6 +73,8 @@ public class ModMaterials {
 			1.1F, Toolbox.MODID);
 	public static final AdornmentMaterial ADORNMENT_ENDER_PEARL = new AdornmentMaterial("ender_pearl", 0, 3F, 1F, 0F,
 			2F, Toolbox.MODID);
+	
+	public static List<HeadMaterial> headMaterials = new ArrayList<HeadMaterial>();
 
 	public static void init() {
 		initHeadMaterials();
@@ -82,7 +84,7 @@ public class ModMaterials {
 	}
 
 	private static void initHeadMaterials() {
-		List<HeadMaterial> headMaterials = new ArrayList<HeadMaterial>();
+		
 
 		OreDictionary.registerOre("flint", Items.FLINT);
 		OreDictionary.registerOre("gravel", Blocks.GRAVEL);

--- a/src/main/java/toolbox/common/recipes/ModRecipes.java
+++ b/src/main/java/toolbox/common/recipes/ModRecipes.java
@@ -159,7 +159,7 @@ public class ModRecipes {
 				HeadMaterial mat = ModItems.mace_head.meta_map.get(i);
 				if (!Config.DISABLE_TOOL_HEAD_RECIPES || !CommonProxy.smelteryMaterials.contains(mat)) {
 					if (Config.ENABLE_SCHEMATICS) {
-						ForgeRegistries.RECIPES.register(getToolHeadSchematicRecipe(new ItemStack(ModItems.mace_head, 1, i), mat.getCraftingItem(), "hammer_head", 4).setRegistryName(new ResourceLocation(Toolbox.MODID, "mace_head_" + mat.getName())));
+						ForgeRegistries.RECIPES.register(getToolHeadSchematicRecipe(new ItemStack(ModItems.mace_head, 1, i), mat.getCraftingItem(), "mace_head", 4).setRegistryName(new ResourceLocation(Toolbox.MODID, "mace_head_" + mat.getName())));
 					} else {
 						ForgeRegistries.RECIPES.register(new ShapedOreRecipe(null, new ItemStack(ModItems.mace_head, 1, i), "SPS", "PPP", "SPS", 'P', mat.getCraftingItem(), 'S', mat.getSmallCraftingItem()).setRegistryName(new ResourceLocation(Toolbox.MODID, "mace_head_" + mat.getName())));
 					}


### PR DESCRIPTION
Fixed #5.
Also improved the removing of vanilla tool recipes by giving the option to remove all vanilla tool recipes (as before this fix) or to only remove the recipes that use materials that we add support for, based on the head materials (plus diamond and diamond ingot).